### PR TITLE
fix(build): include fedora openblas dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ LOGFLAGS  = -DLOG_LEVEL=1
 INC_DIR   = headers
 
 CFLAGS = -std=c11 $(WARNFLAGS) $(OPTFLAGS) $(VECFLAGS) $(LIBFLAGS) $(LOGFLAGS) -fopenmp -I$(INC_DIR) -I/usr/include/openblas
-CFLAGS_DEBUG = $(WARNFLAGS) $(DBGFLAGS) $(LIBFLAGS) $(LOGFLAGS) -fopenmp -I$(INC_DIR) -std=c11
+CFLAGS_DEBUG = $(WARNFLAGS) $(DBGFLAGS) $(LIBFLAGS) $(LOGFLAGS) -fopenmp -I$(INC_DIR) -I/usr/include/openblas -std=c11
 LDFLAGS = -lm -lfftw3 -lfftw3f -lsndfile -lpng -fopenmp -lopenblas
 
 # Directory Structure

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ LOGFLAGS  = -DLOG_LEVEL=1
 
 INC_DIR   = headers
 
-CFLAGS = -std=c11 $(WARNFLAGS) $(OPTFLAGS) $(VECFLAGS) $(LIBFLAGS) $(LOGFLAGS) -fopenmp -I$(INC_DIR)
+CFLAGS = -std=c11 $(WARNFLAGS) $(OPTFLAGS) $(VECFLAGS) $(LIBFLAGS) $(LOGFLAGS) -fopenmp -I$(INC_DIR) -I/usr/include/openblas
 CFLAGS_DEBUG = $(WARNFLAGS) $(DBGFLAGS) $(LIBFLAGS) $(LOGFLAGS) -fopenmp -I$(INC_DIR) -std=c11
 LDFLAGS = -lm -lfftw3 -lfftw3f -lsndfile -lpng -fopenmp -lopenblas
 


### PR DESCRIPTION
I had to change this for the build to be successful in my Fedora 42 system

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to include OpenBLAS headers and adjusted debug build flag ordering to improve compilation reliability on systems where headers reside in /usr/include/openblas. No runtime or functional changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->